### PR TITLE
Improve Instagram error logging

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -59,10 +59,17 @@ def _fetch_instagram_info(username: str) -> Optional[dict]:
         LOGGER.exception("Request to %s failed", url)
         return None
     if response.status_code != 200:
+        try:
+            error_detail = response.json()
+        except ValueError:
+            error_detail = response.text
         LOGGER.warning(
-            "Non-success status code %s for %s", response.status_code, url
+            "Non-success status code %s for %s: %s",
+            response.status_code,
+            url,
+            error_detail,
         )
-        return {"status_code": response.status_code}
+        return {"status_code": response.status_code, "error": error_detail}
     try:
         return response.json()
     except ValueError:


### PR DESCRIPTION
## Summary
- log Instagram API error details when response status is not 200

## Testing
- `python -m py_compile telegram_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a59fd98e2c832abc9944cf6b590b7f