### PR TITLE
Format profile info via helper function

### DIFF
--- a/messages.py
+++ b/messages.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+from telegram.helpers import escape_markdown
+
 
 DEFAULT_LANG = "fa"
 
@@ -25,3 +27,54 @@ def get_message(key: str, lang: str = DEFAULT_LANG, **kwargs: Any) -> str:
     data = _translations.get(lang) or _translations[DEFAULT_LANG]
     text = data.get(key, "")
     return text.format(**kwargs)
+
+
+# Labels used for formatting profile information in different languages.
+_PROFILE_LABELS = {
+    "fa": {
+        "id": "آیدی عددی",
+        "full_name": "نام کامل",
+        "bio": "بیوگرافی",
+        "followers": "فالوورها",
+        "following": "دنبال‌شوندگان",
+        "media_count": "تعداد پست‌ها",
+        "is_private": "خصوصی",
+    },
+    "en": {
+        "id": "ID",
+        "full_name": "Full name",
+        "bio": "Bio",
+        "followers": "Followers",
+        "following": "Following",
+        "media_count": "Posts",
+        "is_private": "Private",
+    },
+}
+
+
+def format_profile_info(user: dict, lang: str = DEFAULT_LANG) -> str:
+    """Return a formatted list of user profile information.
+
+    All user-supplied values are escaped for safe usage with
+    :class:`telegram.constants.ParseMode.MARKDOWN_V2`.
+    """
+
+    labels = _PROFILE_LABELS.get(lang, _PROFILE_LABELS[DEFAULT_LANG])
+
+    def esc(value: Any) -> str:
+        return escape_markdown(str(value), version=2)
+
+    is_private = (
+        get_message("yes", lang) if user.get("is_private") else get_message("no", lang)
+    )
+
+    lines = [
+        f"• 👤 *{labels['id']}:* `{esc(user.get('id', '—'))}`",
+        f"• 📛 *{labels['full_name']}:* {esc(user.get('full_name', '') or '—')}",
+        f"• 📝 *{labels['bio']}:* {esc(user.get('biography', '') or '—')}",
+        f"• 👥 *{labels['followers']}:* `{esc(user.get('follower_count') or 0)}`",
+        f"• 🤝 *{labels['following']}:* `{esc(user.get('following_count') or 0)}`",
+        f"• 📸 *{labels['media_count']}:* `{esc(user.get('media_count') or 0)}`",
+        f"• 🔒 *{labels['is_private']}:* {esc(is_private)}",
+    ]
+    return "\n".join(lines)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -203,43 +203,7 @@ async def handle_username(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         )
         return
     context.user_data["profile_pic_url"] = user.get("profile_pic_url")
-    is_private = (
-        messages.get_message("yes", lang)
-        if user.get("is_private")
-        else messages.get_message("no", lang)
-    )
-    text = messages.get_message(
-        "profile",
-        lang,
-        id=escape_markdown(str(user.get("id", "—")), version=2),
-        full_name=escape_markdown(user.get("full_name", ""), version=2),
-        bio=escape_markdown(user.get("biography", "") or "—", version=2),
-        followers=escape_markdown(
-            str(
-                user.get("follower_count")
-                or user.get("edge_followed_by", {}).get("count")
-                or 0
-            ),
-            version=2,
-        ),
-        following=escape_markdown(
-            str(
-                user.get("following_count")
-                or user.get("edge_follow", {}).get("count")
-                or 0
-            ),
-            version=2,
-        ),
-        media_count=escape_markdown(
-            str(
-                user.get("media_count")
-                or user.get("edge_owner_to_timeline_media", {}).get("count")
-                or 0
-            ),
-            version=2,
-        ),
-        is_private=escape_markdown(is_private, version=2),
-    )
+    text = messages.format_profile_info(user, lang)
     caption = text
     photo_url = user.get("profile_pic_url")
     if photo_url:


### PR DESCRIPTION
## Summary
- add language-aware `format_profile_info` helper to build Markdown bullet list of profile details
- use `format_profile_info` in `handle_username` instead of manual string assembly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f869cbb4832a976c5b6a92b30fd6