### PR TITLE
feat: add first-time welcome message

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -109,8 +109,24 @@ def _fetch_instagram_info_cache_clear() -> None:
 _fetch_instagram_info.cache_clear = _fetch_instagram_info_cache_clear
 
 
+async def send_welcome_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send a friendly Persian welcome message explaining the bot."""
+    lang = _get_lang(context)
+    text = escape_markdown(
+        "👋 به InstaIDBot خوش آمدی! این ربات اطلاعات عمومی حساب‌های اینستاگرام را می‌گیرد و به صورت خلاصه برات می‌فرسته. کافی هست نام کاربری رو بفرستی 😊",
+        version=2,
+    )
+    await update.message.reply_text(
+        text, parse_mode=ParseMode.MARKDOWN_V2, reply_markup=_main_menu(lang)
+    )
+
+
 async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await context.bot.send_chat_action(update.effective_chat.id, ChatAction.TYPING)
+    if not context.user_data.get("started"):
+        await send_welcome_message(update, context)
+        context.user_data["started"] = True
+        return
     lang = _get_lang(context)
     text = escape_markdown(messages.get_message("start", lang), version=2)
     await update.message.reply_text(


### PR DESCRIPTION
## Summary
- show a friendly Persian welcome message explaining the bot
- display the welcome only the first time a user sends /start

## Testing
- `pip install -r requirements.txt` (fails: this environment is externally managed)
- `pytest` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a60f1a8070832aa05a1adbbdbea3bf