### PR TITLE
fix: update bot polling shutdown call

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -307,7 +307,7 @@ async def main() -> None:
     await application.start()
     await application.bot.set_my_commands([("start", "شروع ربات")])
     await application.updater.start_polling()
-    await application.updater.wait_closed()
+    await application.wait_until_closed()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace deprecated `application.updater.wait_closed()` call with `application.wait_until_closed()` in the Telegram bot

## Testing
- `TELEGRAM_BOT_TOKEN=1 python telegram_bot.py` *(fails: telegram.error.NetworkError: httpx.ProxyError: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a81f8d7438832a8ff4ffc803a26737