### PR TITLE
Use updater wait_until_closed in Telegram bot

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -307,7 +307,7 @@ async def main() -> None:
     await application.start()
     await application.bot.set_my_commands([("start", "شروع ربات")])
     await application.updater.start_polling()
-    await application.wait_until_closed()
+    await application.updater.wait_until_closed()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run application.updater.wait_until_closed() in main to avoid missing method

## Testing
- `pytest -q`
- ⚠️ `TELEGRAM_BOT_TOKEN='123:ABC' python telegram_bot.py` *(fails: httpx.ProxyError: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8214096dc832abdac93c891b98972