### PR TITLE
Refactor language menu handling

### DIFF
--- a/tests/test_handle_username.py
+++ b/tests/test_handle_username.py
@@ -57,6 +57,7 @@ def test_handle_username_success(monkeypatch):
         reply_markup=telegram_bot._back_menu(messages.DEFAULT_LANG),
     )
     assert context.user_data["profile_pic_url"] == "http://pic"
+    assert context.user_data["menu"] == "back"
 
 
 def test_handle_username_http_error(monkeypatch):
@@ -72,6 +73,7 @@ def test_handle_username_http_error(monkeypatch):
         parse_mode=ParseMode.MARKDOWN_V2,
         reply_markup=telegram_bot._back_menu(messages.DEFAULT_LANG),
     )
+    assert context.user_data["menu"] == "back"
 
 
 def test_handle_username_network_error(monkeypatch):
@@ -85,3 +87,4 @@ def test_handle_username_network_error(monkeypatch):
         parse_mode=ParseMode.MARKDOWN_V2,
         reply_markup=telegram_bot._back_menu(messages.DEFAULT_LANG),
     )
+    assert context.user_data["menu"] == "back"

--- a/tests/test_language_buttons.py
+++ b/tests/test_language_buttons.py
@@ -20,29 +20,30 @@ class DummyUpdate(SimpleNamespace):
 
 
 class DummyContext(SimpleNamespace):
-    def __init__(self):
+    def __init__(self, user_data=None):
         super().__init__(
-            user_data={},
+            user_data=user_data or {},
             bot=SimpleNamespace(send_chat_action=AsyncMock()),
         )
 
 
-def test_set_language_fa():
+def test_set_language_fa_from_main():
     update = DummyUpdate(messages.get_message("btn_lang_fa"))
-    context = DummyContext()
+    context = DummyContext({"language_prev_menu": "main"})
     asyncio.run(telegram_bot.set_language_fa(update, context))
     expected = escape_markdown(messages.get_message("language_set_fa", "fa"), version=2)
     update.message.reply_text.assert_awaited_with(
         expected,
         parse_mode=ParseMode.MARKDOWN_V2,
-        reply_markup=telegram_bot._back_menu("fa"),
+        reply_markup=telegram_bot._main_menu("fa"),
     )
     assert context.user_data["lang"] == "fa"
+    assert context.user_data["menu"] == "main"
 
 
-def test_set_language_en():
+def test_set_language_en_from_back():
     update = DummyUpdate(messages.get_message("btn_lang_en"))
-    context = DummyContext()
+    context = DummyContext({"language_prev_menu": "back"})
     asyncio.run(telegram_bot.set_language_en(update, context))
     expected = escape_markdown(messages.get_message("language_set_en", "en"), version=2)
     update.message.reply_text.assert_awaited_with(
@@ -51,4 +52,5 @@ def test_set_language_en():
         reply_markup=telegram_bot._back_menu("en"),
     )
     assert context.user_data["lang"] == "en"
+    assert context.user_data["menu"] == "back"
 

--- a/tests/test_other_menus.py
+++ b/tests/test_other_menus.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import asyncio
+
+from telegram.constants import ParseMode
+from telegram.helpers import escape_markdown
+
+import messages
+import telegram_bot
+
+
+class DummyMessage(SimpleNamespace):
+    def __init__(self, text):
+        super().__init__(text=text, reply_text=AsyncMock())
+
+
+class DummyUpdate(SimpleNamespace):
+    def __init__(self, text):
+        super().__init__(message=DummyMessage(text), effective_chat=SimpleNamespace(id=1))
+
+
+class DummyContext(SimpleNamespace):
+    def __init__(self, user_data=None):
+        super().__init__(
+            user_data=user_data or {},
+            bot=SimpleNamespace(send_chat_action=AsyncMock()),
+        )
+
+
+def test_help_shows_main_menu():
+    update = DummyUpdate(messages.get_message("btn_help"))
+    context = DummyContext()
+    asyncio.run(telegram_bot.help_command(update, context))
+    expected = escape_markdown(messages.get_message("help", messages.DEFAULT_LANG), version=2)
+    update.message.reply_text.assert_awaited_with(
+        expected,
+        parse_mode=ParseMode.MARKDOWN_V2,
+        reply_markup=telegram_bot._main_menu(messages.DEFAULT_LANG),
+    )
+    assert context.user_data["menu"] == "main"
+
+
+def test_back_to_menu_shows_main_menu():
+    update = DummyUpdate(messages.get_message("btn_back"))
+    context = DummyContext()
+    asyncio.run(telegram_bot.back_to_menu(update, context))
+    expected = escape_markdown(messages.get_message("start", messages.DEFAULT_LANG), version=2)
+    update.message.reply_text.assert_awaited_with(
+        expected,
+        parse_mode=ParseMode.MARKDOWN_V2,
+        reply_markup=telegram_bot._main_menu(messages.DEFAULT_LANG),
+    )
+    assert context.user_data["menu"] == "main"
+
+
+def test_language_command_shows_language_menu():
+    update = DummyUpdate(messages.get_message("btn_language"))
+    context = DummyContext({"menu": "main"})
+    asyncio.run(telegram_bot.language_command(update, context))
+    expected = escape_markdown(messages.get_message("language_prompt", messages.DEFAULT_LANG), version=2)
+    update.message.reply_text.assert_awaited_with(
+        expected,
+        parse_mode=ParseMode.MARKDOWN_V2,
+        reply_markup=telegram_bot._language_menu(messages.DEFAULT_LANG),
+    )
+    assert context.user_data["language_prev_menu"] == "main"

--- a/tests/test_start_menu.py
+++ b/tests/test_start_menu.py
@@ -39,4 +39,5 @@ def test_start_shows_main_menu():
         parse_mode=ParseMode.MARKDOWN_V2,
         reply_markup=telegram_bot._main_menu(messages.DEFAULT_LANG),
     )
+    assert context.user_data["menu"] == "main"
 


### PR DESCRIPTION
## Summary
- Add `_language_menu` for dedicated language selection keyboard
- Show language choices via `_language_menu` and return to main or back menu after language change
- Track menu state so operational replies use back button only
- Expand test suite to cover help/back/language flows

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2baf7d6a4832a8b5309e65592d629